### PR TITLE
pre-commit 3.2.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# Remove this tag when the underlying issue https://github.com/anaconda-distribution/rocket-platform/pull/751
+# will be resolved.
+pkg_build_image_tag: '2023.03.24'

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,1 +1,5 @@
-${PYTHON} -m pip install . --no-deps -vv
+#!/bin/bash
+
+set -ex
+
+"${PYTHON}" -m pip install . --no-deps -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-set -ex
-
 "${PYTHON}" -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,10 +50,6 @@ outputs:
       commands:
         - pip check
         - pre-commit --help
-        - pre-commit validate-config --help  # [not win]
-        - pre-commit validate-manifest --help  # [not win]
-        - pre-commit-validate-config --help  # [win]
-        - pre-commit-validate-manifest --help  # [win]
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.0" %}
+{% set version = "3.2.1" %}
 
 package:
   name: pre-commit-split
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
-  sha256: 5c4b29667e824926f63093b1d8bb85fead65aad477c9b6b63dba19ed320d7c6e
+  sha256: 5cc587e824a9dde28e2668f3da547da10607f7e531bdf8a6c1e8a9bdc7134570
 
 build:
   number: 0
@@ -50,8 +50,8 @@ outputs:
       commands:
         - pip check
         - pre-commit --help
-        - pre-commit-validate-config --help
-        - pre-commit-validate-manifest --help
+        - pre-commit validate-config --help
+        - pre-commit validate-manifest --help
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,27 @@
-{% set version = "2.20.0" %}
+{% set version = "3.11.1" %}
 
 package:
-  name: pre-commit
+  name: pre-commit-split
   version: {{ version }}
 
 source:
   url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
-  sha256: 380ca8e6ea7d4b3d851b6656aa861e51fa52e023b82e2b0781d43a602f9cb81f
+  sha256: 6d3189fcb39dc97977d9f705b8f3bb570a613ef1e9cd598d958a82c503fda5a3
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   entry_points:
     - pre-commit = pre_commit.main:main
     - pre-commit-validate-config = pre_commit.clientlib:validate_config_main
     - pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
 
 outputs:
   - name: pre-commit
@@ -29,12 +36,10 @@ outputs:
       run:
         - cfgv >=2.0.0
         - identify >=1.0.0
-        - importlib_metadata  # [py<38]
         - nodeenv >=0.11.1
         - python
         - pyyaml >=5.1
-        - toml
-        - virtualenv >=20.0.8
+        - virtualenv >=20.10.0
     test:
       requires:
         - pip
@@ -64,7 +69,10 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: A framework for managing and maintaining multi-language pre-commit hooks.
-  license_family: MIT
+  description: |
+    pre-commit is a framework for managing and maintaining multi-language pre-commit hooks.
+    It allows you to ensure that your code meets quality standards before you commit changes.
+    pre-commit is language agnostic and plays nicely with other pre-commit tools.
   dev_url: https://github.com/pre-commit/pre-commit
   doc_url: https://pre-commit.com/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ outputs:
         - pre_commit.resources
       commands:
         - pip check
-        - pre-commit -V
+        - python -m pre-commit -V
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.1" %}
+{% set version = "3.2.0" %}
 
 package:
   name: pre-commit-split
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
-  sha256: 6d3189fcb39dc97977d9f705b8f3bb570a613ef1e9cd598d958a82c503fda5a3
+  sha256: 5c4b29667e824926f63093b1d8bb85fead65aad477c9b6b63dba19ed320d7c6e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,10 @@ outputs:
       commands:
         - pip check
         - pre-commit --help
-        - pre-commit validate-config --help
-        - pre-commit validate-manifest --help
+        - pre-commit validate-config --help  # [not win]
+        - pre-commit validate-manifest --help  # [not win]
+        - pre-commit-validate-config --help  # [win]
+        - pre-commit-validate-manifest --help  # [win]
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,9 +47,11 @@ outputs:
         - pre_commit
         - pre_commit.commands
         - pre_commit.languages
+        - pre_commit.meta_hooks
+        - pre_commit.resources
       commands:
         - pip check
-        - pre-commit --help
+        - pre-commit help
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   skip: true  # [py<38]
   entry_points:
     - pre-commit = pre_commit.main:main
-    - pre-commit-validate-config = pre_commit.clientlib:validate_config_main
-    - pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
 
 requirements:
   host:
@@ -51,7 +49,7 @@ outputs:
         - pre_commit.resources
       commands:
         - pip check
-        - pre-commit help
+        - pre-commit -V
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,8 @@ outputs:
       commands:
         - pip check
         - pre-commit --help
-        - pre-commit validate-config --help
-        - pre-commit validate-manifest --help
+        - pre-commit-validate-config --help
+        - pre-commit-validate-manifest --help
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "3.11.1" %}
+{% set version = "3.1.1" %}
 
 package:
   name: pre-commit-split
   version: {{ version }}
 
 source:
-  url: https://github.com/pre-commit/pre-commit/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
   sha256: 6d3189fcb39dc97977d9f705b8f3bb570a613ef1e9cd598d958a82c503fda5a3
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
+  url: https://github.com/pre-commit/pre-commit/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 6d3189fcb39dc97977d9f705b8f3bb570a613ef1e9cd598d958a82c503fda5a3
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,8 @@ outputs:
       commands:
         - pip check
         - pre-commit --help
-        - pre-commit-validate-config --help
-        - pre-commit-validate-manifest --help
+        - pre-commit validate-config --help
+        - pre-commit validate-manifest --help
 
   - name: pre_commit
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,9 +47,7 @@ outputs:
         - pre_commit.languages
         - pre_commit.meta_hooks
         - pre_commit.resources
-      commands:
-        - pip check
-        - python -m pre-commit -V
+      # Test commands are in run_test.sh and run_test.bat
 
   - name: pre_commit
     build:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,4 @@
+pip check
+
+%PYTHON% pre-commit --help
+%PYTHON% pre-commit -V

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+pip check
+
+"${PYTHON}" pre-commit --help
+"${PYTHON}" pre-commit -V

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ex
-
 pip check
 
 "${PYTHON}" pre-commit --help


### PR DESCRIPTION
Changelog: https://github.com/pre-commit/pre-commit/blob/v3.2.1/CHANGELOG.md
License: https://github.com/pre-commit/pre-commit/blob/v3.2.1/LICENSE
Requirements: https://github.com/pre-commit/pre-commit/blob/v3.2.1/setup.cfg


Actions:
1. Update build.sh
2. Skip py<38
3. Add a generic host environment
4. Update run dependencies: remove importlib_metadata for py<38, remove toml, update virtualenv pinning
5. Update test/imports
6. Move test/commands to run_test.sh and run_test.bat to avoid a pretty weird error on win64 when the command pre-commit --help fails without a reason. I guess it's a conda-build or Prefect bug
7. Add description